### PR TITLE
Expose option to change the device hostname.

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -126,6 +126,9 @@
     <string name="security_settings_fingerprint_sensor_location_left">left side</string>
     <string name="security_settings_fingerprint_sensor_location_right">right side</string>
 
+    <!-- Hostname setting -->
+    <string name="device_hostname">Device hostname</string>
+
     <!-- Increasing ring tone volume -->
     <string name="increasing_ring_volume_option_title">Increasing ring volume</string>
     <string name="increasing_ring_min_volume_title">Start volume</string>

--- a/res/xml/development_prefs.xml
+++ b/res/xml/development_prefs.xml
@@ -155,6 +155,17 @@
         <Preference android:key="clear_adb_keys"
                 android:title="@string/clear_adb_keys" />
 
+        <org.lineageos.internal.preference.HostnamePreference
+            android:key="device_hostname"
+            android:title="@string/device_hostname"
+            android:dialogTitle="@string/device_hostname"
+            android:positiveButtonText="@string/wifi_save"
+            android:negativeButtonText="@string/wifi_cancel"
+            android:selectAllOnFocus="true"
+            android:imeOptions="actionDone"
+            android:inputType="textNoSuggestions"
+            android:persistent="false" />
+
         <SwitchPreference
             android:key="enable_terminal"
             android:title="@string/enable_terminal_title"


### PR DESCRIPTION
This adds an option to modify the device hostname used
in ip resolution. This is useful when connecting to the
android device in a dynamic dhcp environment.

Change-Id: I1d8302f06144dbb3e6ddba68594cc5718b4f0bb7
(based on commit Ibc145b74036617248d4f33c6866cc9c8a8cc8974)